### PR TITLE
Fix request retry logic, remove free proxy and update domain URL to avoid channel ID collision

### DIFF
--- a/network.py
+++ b/network.py
@@ -57,11 +57,11 @@ def make_request(url, clear_cookies=True, timeout=60, *args, **kwargs):
     while True:
         try:
             response = sess.get(url, headers=headers, timeout=timeout, *args, **kwargs)
-            retry_count_500 += 1
             if response.status_code == 500:
+                retry_count_500 += 1
                 time.sleep(retry_count_500 * 1)
                 continue
-            if retry_count_500 >= max_retries:
+            if retry_count_500 >= max_retries or response.status_code == 200:
                 break
         except (
             requests.exceptions.ConnectionError,
@@ -132,7 +132,7 @@ def get_subtitles_using_api(youtube_id):
 
 def get_subtitles_using_youtube_dl(youtube_id):
     youtube_url = 'https://youtube.com/watch?v=' + youtube_id
-    yt_resource = YouTubeResource(youtube_url)
+    yt_resource = YouTubeResource(youtube_url, useproxy=False)
     lang_codes = []
     try:
         result = yt_resource.get_resource_subtitles()

--- a/sushichef.py
+++ b/sushichef.py
@@ -107,7 +107,7 @@ class KhanAcademySushiChef(JsonTreeChef):
         # Build dict with all the info required to create the ChannelNode object
         channel_dict = dict(
             source_id=channel_source_id,
-            source_domain="khanacademy.org",
+            source_domain=f"{lang}.khanacademy.org",
             title=get_channel_title(lang=lang, variant=variant),
             description=get_channel_description(lang=lang, variant=variant),
             thumbnail=os.path.join("chefdata", "khan-academy-logo.png"),


### PR DESCRIPTION
- Requests were made to Khan API 5 times even if it succeeded in the
  first try, fixed the logic
- The youtube resource uses free proxies from
  `https://api.proxyscrape.com/?request=getproxies`, the proxies didn't
  seem to work very well and took a lot of time, the proxy use is removed
  now.
- The UUID for channel upload caused collision with existing KA channels
  in kolibri studio, updated the logic to create different channel IDs